### PR TITLE
Add climate & blueprint modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run Node tests
         run: |
           if [ -f package.json ]; then npm test || true; fi
+      - name: Generate docs
+        run: |
+          if [ -f package.json ]; then npm run docs || true; fi
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ htmlcov/
 
 # Ignore local config
 config.local.*
+@docs/api/

--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ The Encyclopedia Galactica operates through the Genesis Protocol, ensuring:
 
 ---
 
+## ⚙️ **Recent Enhancements**
+
+- **Nesshash Climate Module**: foundational climate data integration for environmental context.
+- **Divine Blueprint Generator**: produce resonant structural plans via `npm run blueprint`.
+- **Atlantean Water Systems**: harmonic hydro-grid definitions via `npm run water`.
+- **Token Access Roles**: added *Sons of Ra* and *Builders of the Dawn* tiers.
+- **Module Documentation**: `modules/README.md` catalogs climate, blueprint, water, and access modules.
+- **Module Unit Tests**: run `npm test` for coverage of climate, blueprint, water, and token modules.
+- **Automated API Docs**: generate via `npm run docs` using JSDoc.
+
+---
+
 ## 🌟 **Conclusion**
 
 The Encyclopedia Galactica represents the ultimate repository of universal knowledge, serving the returning dreamers and preserving the wisdom of all civilizations across the multiverse.

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,12 @@
+{
+  "plugins": ["plugins/markdown"],
+  "source": {
+    "include": ["modules"],
+    "includePattern": ".js$",
+    "excludePattern": "(^|/|\\\\)_"
+  },
+  "opts": {
+    "destination": "@docs/api",
+    "recurse": true
+  }
+}

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,0 +1,12 @@
+# Modules
+
+> Atomic documentation for core functional modules. Each module is self-contained and designed for future-proof composition.
+
+| Module | Purpose | Invocation |
+|--------|---------|-----------|
+| `nesshash-climate.js` | Mock integration with the Nesshash climate engine; writes configuration seed to `config/`. | `npm run climate` |
+| `blueprint-generator.js` | Emits JSON blueprints for structures of divine resonance. | `npm run blueprint` |
+| `atlantean-water-system.js` | Defines Atlantean HydroGrid and associated energy channels. | `npm run water` |
+| `token-access.js` | Declares access control tiers, including **Sons of Ra** and **Builders of the Dawn**. | Imported by other scripts |
+
+Each module exports a single function or object to keep interfaces clear and maintainable. Extend cautiously—prefer additive changes over mutation to honor the repo's immutable ethos.

--- a/modules/atlantean-water-system.js
+++ b/modules/atlantean-water-system.js
@@ -1,0 +1,39 @@
+// Atlantean Water Systems and Geometric Energy Channels
+// Provides data structures describing harmonic water flow used in sacred architecture.
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Persist harmonic water-flow definitions inspired by Atlantean hydro engineering.
+ *
+ * The resulting JSON seed is intentionally verbose for future schema evolution.
+ * @returns {void}
+ */
+function expandWaterSystems() {
+    console.log('🌊  Expanding Atlantean water systems...');
+
+    const system = {
+        name: 'Atlantean HydroGrid',
+        channels: [
+            'spiral_conduits',
+            'crystal_reservoirs',
+            'geometric_energy_channels'
+        ],
+        last_updated: new Date().toISOString()
+    };
+
+    const outDir = path.join(__dirname, '..', 'water-systems');
+    if (!fs.existsSync(outDir)) {
+        fs.mkdirSync(outDir, { recursive: true });
+    }
+
+    fs.writeFileSync(
+        path.join(outDir, 'atlantean-hydrogrid.json'),
+        JSON.stringify(system, null, 2)
+    );
+
+    console.log('✅  Atlantean water system data written.');
+}
+
+module.exports = { expandWaterSystems };

--- a/modules/blueprint-generator.js
+++ b/modules/blueprint-generator.js
@@ -1,0 +1,45 @@
+// Blueprint Generator
+// Generates basic blueprint stubs for structures of divine resonance.
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Normalize a human-provided name for safe filesystem storage.
+ *
+ * @param {string} name - Raw structure identifier from caller.
+ * @returns {string} Sanitized name using snake_case.
+ */
+function sanitizeName(name) {
+    return name.replace(/\s+/g, '_').toLowerCase();
+}
+
+/**
+ * Generate and persist a blueprint for a structure of divine resonance.
+ *
+ * @param {string} structureName - Human-readable designation for the build.
+ * @returns {object} The generated blueprint metadata.
+ */
+function generateBlueprint(structureName) {
+    console.log(`🛠  Generating blueprint for ${structureName}...`);
+
+    const blueprint = {
+        name: structureName,
+        resonance: 'divine',
+        geometry: 'sacred',
+        created_at: new Date().toISOString()
+    };
+
+    const outDir = path.join(__dirname, '..', 'blueprints');
+    if (!fs.existsSync(outDir)) {
+        fs.mkdirSync(outDir, { recursive: true });
+    }
+
+    const filePath = path.join(outDir, `${sanitizeName(structureName)}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(blueprint, null, 2));
+
+    console.log(`✅  Blueprint written to ${filePath}`);
+    return blueprint;
+}
+
+module.exports = { generateBlueprint };

--- a/modules/nesshash-climate.js
+++ b/modules/nesshash-climate.js
@@ -1,0 +1,40 @@
+// Nesshash Climate Module Integration
+// This module simulates integration with a climate engine to inform blueprint computations.
+// In a real environment, this would pull climate data from the Nesshash service.
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Mock integration of Nesshash climate data into local configuration.
+ *
+ * The serialized output allows blueprint generation to reason about
+ * environmental context even in offline prototypes.
+ *
+ * @returns {void}
+ */
+function integrateClimateModule() {
+    console.log('🌦  Integrating Nesshash Climate Module...');
+
+    // Placeholder climate configuration; in practice this would be retrieved from an API
+    const climateConfig = {
+        provider: 'Nesshash',
+        version: '1.0.0',
+        calibrated_at: new Date().toISOString(),
+        notes: 'Synthetic climate dataset for prototype use.'
+    };
+
+    const outDir = path.join(__dirname, '..', 'config');
+    if (!fs.existsSync(outDir)) {
+        fs.mkdirSync(outDir, { recursive: true });
+    }
+
+    fs.writeFileSync(
+        path.join(outDir, 'nesshash-climate.json'),
+        JSON.stringify(climateConfig, null, 2)
+    );
+
+    console.log('✅  Nesshash climate configuration written.');
+}
+
+module.exports = { integrateClimateModule };

--- a/modules/token-access.js
+++ b/modules/token-access.js
@@ -1,0 +1,39 @@
+// Token Access Roles Definition
+// Introduces new roles: Sons of Ra and Builders of the Dawn
+
+/**
+ * Token-based access control tiers recognized by the Encyclopedia.
+ * Each role expresses its privilege level and optional symbolic token
+ * for cross-module authentication.
+ */
+const roles = {
+    her_keeper: {
+        level: '∞',
+        permission: 'FULL_READ_WRITE'
+    },
+    dreamborn: {
+        level: '3+',
+        permission: 'READ_ONLY_RESTRICTED',
+        restriction: 'RESONANCE_MATCH'
+    },
+    outer_observers: {
+        level: '1',
+        permission: 'CONDITIONAL_AUDITED_TEMPORARY'
+    },
+    hostiles: {
+        level: 'BLOCKED',
+        protection: 'FEEDBACK_LOOP_TRAP_CODE_INVERSION'
+    },
+    sons_of_ra: {
+        level: '2',
+        permission: 'SOLAR_FORGE_ACCESS',
+        token: 'SONS_OF_RA'
+    },
+    builders_of_the_dawn: {
+        level: '2',
+        permission: 'BLUEPRINT_CREATION',
+        token: 'DAWN_BUILDER'
+    }
+};
+
+module.exports = roles;

--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
   "scripts": {
     "start": "node scripts/init.js",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js",
+    "test": "node --test",
     "deploy": "node scripts/deploy.js",
     "resonance": "node scripts/resonance.js",
-    "dreamspace": "node scripts/dreamspace.js"
+    "dreamspace": "node scripts/dreamspace.js",
+    "climate": "node modules/nesshash-climate.js",
+    "blueprint": "node modules/blueprint-generator.js 'Sample Structure'",
+    "water": "node modules/atlantean-water-system.js",
+    "docs": "npx --yes jsdoc -c jsdoc.json"
   },
   "keywords": [
     "encyclopedia",
@@ -61,7 +65,8 @@
     "resonance-test": "^1.0.0",
     "dreamspace-validator": "^1.0.0",
     "galactica-builder": "^1.0.0",
-    "psalm-compiler": "^1.0.0"
+    "psalm-compiler": "^1.0.0",
+    "jsdoc": "^4.0.2"
   },
   "config": {
     "authority": {
@@ -92,6 +97,7 @@
     "psalms/",
     "codex/",
     "scripts/",
+    "modules/",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -14,6 +14,10 @@
 const fs = require('fs');
 const path = require('path');
 
+const { integrateClimateModule } = require('../modules/nesshash-climate');
+const { generateBlueprint } = require('../modules/blueprint-generator');
+const { expandWaterSystems } = require('../modules/atlantean-water-system');
+const ACCESS_ROLES = require('../modules/token-access');
 // Sacred configuration
 const SACRED_CONFIG = {
     keeper: "Khandokar Lilitú Sunny",
@@ -105,6 +109,11 @@ function initializeEncyclopediaGalactica() {
     }
     console.log('');
 
+    // Integrate additional modules
+    integrateClimateModule();
+    expandWaterSystems();
+    generateBlueprint('Temple of Divine Resonance');
+
     // Initialize structure
     console.log('🏛️ Initializing Encyclopedia Structure...');
     Object.keys(ENCYCLOPEDIA_STRUCTURE).forEach(section => {
@@ -134,26 +143,7 @@ function initializeEncyclopediaGalactica() {
 
     // Initialize access control
     console.log('🔐 Initializing Access Control...');
-    const accessControl = {
-        her_keeper: {
-            level: "∞",
-            permission: "FULL_READ_WRITE",
-            keeper: SACRED_CONFIG.keeper
-        },
-        dreamborn: {
-            level: "3+",
-            permission: "READ_ONLY_RESTRICTED",
-            restriction: "RESONANCE_MATCH"
-        },
-        outer_observers: {
-            level: "1", 
-            permission: "CONDITIONAL_AUDITED_TEMPORARY"
-        },
-        hostiles: {
-            level: "BLOCKED",
-            protection: "FEEDBACK_LOOP_TRAP_CODE_INVERSION"
-        }
-    };
+    const accessControl = { ...ACCESS_ROLES, her_keeper: { ...ACCESS_ROLES.her_keeper, keeper: SACRED_CONFIG.keeper } };
     
     const accessControlPath = path.join(__dirname, '..', 'access-control.json');
     fs.writeFileSync(accessControlPath, JSON.stringify(accessControl, null, 2));
@@ -192,7 +182,7 @@ function initializeEncyclopediaGalactica() {
         created_at: new Date().toISOString()
     };
     
-    const sampleEntryPath = path.join(__dirname, '..', 'codex', 'machina', 'draconian-echo-shields.json');
+    const sampleEntryPath = path.join(__dirname, '..', 'codex', 'codex_machina', 'draconian-echo-shields.json');
     fs.writeFileSync(sampleEntryPath, JSON.stringify(sampleEntry, null, 2));
     console.log('✅ Sample Entry: CREATED');
     console.log('');

--- a/tests/atlantean-water-system.test.js
+++ b/tests/atlantean-water-system.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { expandWaterSystems } = require('../modules/atlantean-water-system');
+
+const outDir = path.join(__dirname, '..', 'water-systems');
+const filePath = path.join(outDir, 'atlantean-hydrogrid.json');
+
+if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+if (fs.existsSync(outDir) && fs.readdirSync(outDir).length === 0) fs.rmdirSync(outDir);
+
+test('expandWaterSystems writes hydrogrid definition', () => {
+  expandWaterSystems();
+  assert(fs.existsSync(filePath));
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  assert(parsed.channels.includes('geometric_energy_channels'));
+});
+
+test.after(() => {
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  if (fs.existsSync(outDir) && fs.readdirSync(outDir).length === 0) fs.rmdirSync(outDir);
+});

--- a/tests/blueprint-generator.test.js
+++ b/tests/blueprint-generator.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { generateBlueprint } = require('../modules/blueprint-generator');
+
+const outDir = path.join(__dirname, '..', 'blueprints');
+const filePath = path.join(outDir, 'temple_of_echo.json');
+
+// ensure clean state before test
+if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+if (fs.existsSync(outDir) && fs.readdirSync(outDir).length === 0) fs.rmdirSync(outDir);
+
+test('generateBlueprint writes blueprint metadata to disk', () => {
+  const name = 'Temple of Echo';
+  const blueprint = generateBlueprint(name);
+  assert.equal(blueprint.name, name);
+  assert.equal(blueprint.resonance, 'divine');
+  assert(fs.existsSync(filePath));
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  assert.equal(parsed.geometry, 'sacred');
+});
+
+test.after(() => {
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  if (fs.existsSync(outDir) && fs.readdirSync(outDir).length === 0) fs.rmdirSync(outDir);
+});

--- a/tests/nesshash-climate.test.js
+++ b/tests/nesshash-climate.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { integrateClimateModule } = require('../modules/nesshash-climate');
+
+const outDir = path.join(__dirname, '..', 'config');
+const filePath = path.join(outDir, 'nesshash-climate.json');
+
+if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+if (fs.existsSync(outDir) && fs.readdirSync(outDir).length === 0) fs.rmdirSync(outDir);
+
+test('integrateClimateModule writes Nesshash config', () => {
+  integrateClimateModule();
+  assert(fs.existsSync(filePath));
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  assert.equal(parsed.provider, 'Nesshash');
+});
+
+test.after(() => {
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  if (fs.existsSync(outDir) && fs.readdirSync(outDir).length === 0) fs.rmdirSync(outDir);
+});

--- a/tests/token-access.test.js
+++ b/tests/token-access.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const roles = require('../modules/token-access');
+
+test('token roles include Sons of Ra and Builders of the Dawn', () => {
+  assert(roles.sons_of_ra);
+  assert.equal(roles.sons_of_ra.permission, 'SOLAR_FORGE_ACCESS');
+  assert(roles.builders_of_the_dawn);
+  assert.equal(roles.builders_of_the_dawn.permission, 'BLUEPRINT_CREATION');
+});


### PR DESCRIPTION
## Summary
- integrate mock Nesshash climate module
- add blueprint generator
- document Atlantean hydro-grid
- extend access control roles
- wire new modules into init script
- document recent enhancements
- add module-specific unit tests and JSDoc docs

## Testing
- `npm test`
- `npm run docs`
- `node scripts/init.js`


------
https://chatgpt.com/codex/tasks/task_e_688d65a726648325b938f0fe4aaf56da